### PR TITLE
追加　永続的識別子として運用する場合の設計方針

### DIFF
--- a/463-1_コード（分類体系）導入実践ガイドブック.md
+++ b/463-1_コード（分類体系）導入実践ガイドブック.md
@@ -128,11 +128,28 @@ ISOやJIS、業界団体等によって標準化されたコードを使うこ�
 
 サービスを構築するたびにコード再設計を行うことは、設計時間や費用が無駄になるだけでなく、品質の劣化などにも繋がるおそれがあります。また、コード設計は、将来の追加・変更等を見据えた中長期的な視点で行う必要があります。
 
-以下に、本ガイドブックが示すコード設計の基本的方針を示します。
-- 既存のコードがあるときには、そのコードを利用します。
+以下に、本ガイドブックが示すコード設計の基本的方針を示します。 
+- コードを永続的識別子なのか、それとも永続的でないもしくは非公開情報を含む情報とするかを決定します。永続とは発番してから未来永劫変わらないことを意味します。
+- 既存のコードがあるか調べます。
+
+### 永続的でないか非公開情報を含む情報を含む場合
+- 既存のコードがなければ新しく設計します。
+- 既存のコードを使える場合はそのコードを利用します。
 - 既存のコードがあるがそのまま使えないときには、分類を追加したり、扱える件数を増やす等の拡張を行います。
 - 新しくコードを設計する場合には、中長期的な利用やデータ連携を前提として設計します。
 - 既存のコードを利用しているが改善の必要がある場合には、コード変更による効果と影響を見極めた上で、コードの変更を行います。
+
+### 永続的識別子の場合
+永続的識別子の国際標準に従い、標準に書かれていない場合は永続的でないか非公開情報を含む情報を含む場合と同様の運用をします。
+
+#### 永続的識別子の国際標準
+- [RFC Uniform Resource Identifier (URI): 一般規則](https://datatracker.ietf.org/doc/html/rfc3986)
+- [RFC URI Design and Ownership](https://datatracker.ietf.org/doc/html/rfc8820)
+- [FAIR原則](https://biosciencedbc.jp/about-us/report/fair-data-principle/)
+- [w3c Best Practices URI Construction](https://www.w3.org/2011/gld/wiki/223_Best_Practices_URI_Construction)
+- [２１世紀の識別子の設計](https://journals.plos.org/plosbiology/article?id=10.1371/journal.pbio.2001414)
+- [EU 永続的識別子ポリシー](https://op.europa.eu/en/publication-detail/-/publication/35c5ca10-1417-11eb-b57e-01aa75ed71a1/language-en)
+- [w3c WWWのアーキテクチャ](https://www.w3.org/TR/2004/REC-webarch-20041215/)
 
 ### 3.1. コード設計の手順
 


### PR DESCRIPTION
設計標準にはrfc と　w3c以外に w3cに引用されている資料とEUの標準を追加